### PR TITLE
添加标签统计计数功能

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import AnniversaryList from './components/AnniversaryList';
 import AnniversaryForm from './components/AnniversaryForm';
 import ConfirmDialog from './components/ConfirmDialog';
 import RecycleBin from './components/RecycleBin';
+import TagStats from './components/TagStats';
 import useLocalStorage from './hooks/useLocalStorage';
 import useNotifications from './hooks/useNotifications';
 import {
@@ -196,6 +197,8 @@ function App() {
           onDelete={handleDelete}
           onAddClick={handleAddClick}
         />
+
+        <TagStats anniversaries={anniversaries} trashCount={trash.length} />
       </main>
 
       {/* Form Modal */}

--- a/src/components/TagStats.css
+++ b/src/components/TagStats.css
@@ -1,0 +1,88 @@
+.tag-stats {
+  max-width: 1200px;
+  margin: var(--spacing-2xl) auto var(--spacing-lg);
+  padding: 0 var(--spacing-md);
+}
+
+.tag-stats-inner {
+  background: white;
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-lg) var(--spacing-xl);
+  box-shadow: var(--shadow-sm);
+  border: 1px solid var(--color-primary);
+}
+
+.tag-stats-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--spacing-md);
+}
+
+.tag-stats-title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-secondary);
+}
+
+.tag-stats-total {
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  opacity: 0.6;
+}
+
+.tag-stats-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+}
+
+.tag-stats-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  background: var(--color-background);
+  border-radius: var(--radius-full);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  transition: transform var(--transition-fast);
+}
+
+.tag-stats-item:hover {
+  transform: translateY(-1px);
+}
+
+.tag-stats-badge {
+  display: inline-block;
+  padding: 2px var(--spacing-sm);
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+  white-space: nowrap;
+}
+
+.tag-stats-badge-trash {
+  background-color: #e0e0e0;
+}
+
+.tag-stats-count {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-secondary);
+  min-width: 1.5em;
+  text-align: center;
+}
+
+@media (max-width: 640px) {
+  .tag-stats-inner {
+    padding: var(--spacing-md);
+  }
+
+  .tag-stats-tags {
+    gap: var(--spacing-xs);
+  }
+
+  .tag-stats-badge {
+    font-size: var(--font-size-xs);
+  }
+}

--- a/src/components/TagStats.jsx
+++ b/src/components/TagStats.jsx
@@ -1,0 +1,58 @@
+import React, { useMemo } from 'react';
+import './TagStats.css';
+
+const CATEGORY_CONFIG = {
+  birthday: { label: '🎂 Birthday', color: '#FFB6C1' },
+  wedding: { label: '💒 Wedding', color: '#FF69B4' },
+  work: { label: '💼 Work', color: '#87CEEB' },
+  other: { label: '🎈 Other', color: '#DDA0DD' },
+};
+
+function TagStats({ anniversaries, trashCount }) {
+  const categoryCounts = useMemo(() => {
+    const counts = {};
+    for (const key of Object.keys(CATEGORY_CONFIG)) {
+      counts[key] = 0;
+    }
+    for (const a of anniversaries) {
+      const cat = a.category || 'other';
+      if (counts[cat] !== undefined) {
+        counts[cat]++;
+      } else {
+        counts.other++;
+      }
+    }
+    return counts;
+  }, [anniversaries]);
+
+  const total = anniversaries.length;
+
+  return (
+    <footer className="tag-stats">
+      <div className="tag-stats-inner">
+        <div className="tag-stats-header">
+          <span className="tag-stats-title">Statistics</span>
+          <span className="tag-stats-total">{total} total</span>
+        </div>
+        <div className="tag-stats-tags">
+          {Object.entries(CATEGORY_CONFIG).map(([key, { label, color }]) => (
+            <div className="tag-stats-item" key={key}>
+              <span className="tag-stats-badge" style={{ backgroundColor: color }}>
+                {label}
+              </span>
+              <span className="tag-stats-count">{categoryCounts[key]}</span>
+            </div>
+          ))}
+          <div className="tag-stats-item">
+            <span className="tag-stats-badge tag-stats-badge-trash">
+              🗑️ Trash
+            </span>
+            <span className="tag-stats-count">{trashCount}</span>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+export default TagStats;


### PR DESCRIPTION
## Summary
- 在主页面底部新增标签统计区域，展示各分类（Birthday、Wedding、Work、Other）的纪念日数量
- 同时显示垃圾桶中纪念日的个数
- 统计数据随纪念日增删和回收站变化实时更新

## Changes
- 新增 `TagStats.jsx` 组件和 `TagStats.css` 样式
- 在 `App.jsx` 中集成 `TagStats` 组件